### PR TITLE
Fix snooze window not reopening after snoozing

### DIFF
--- a/BreakTimer/BreakTimer/App.xaml.cs
+++ b/BreakTimer/BreakTimer/App.xaml.cs
@@ -236,7 +236,12 @@ namespace BreakTimer
                     overlay = new OverlayWindow(stretchText, snoozeMinutes, false);
                 }
 
-                overlay.OnSnoozeRequested = () => workTimer.AddTime(TimeSpan.FromMinutes(snoozeMinutes));
+                overlay.OnSnoozeRequested = () =>
+                {
+                    workTimer.AddTime(TimeSpan.FromMinutes(snoozeMinutes));
+                    // allow snooze popup to reappear for the newly added time
+                    snoozeAlreadyShown = false;
+                };
                 overlay.OnClosedByUser = () => {
                     CloseOverlay();
                     workTimer.Start(workMinutes);
@@ -265,6 +270,8 @@ namespace BreakTimer
             snoozeWindow.OnSnoozeRequested = () =>
             {
                 workTimer.AddTime(TimeSpan.FromMinutes(snoozeMinutes));
+                // reset flag so window can appear again if needed
+                snoozeAlreadyShown = false;
                 CloseSnoozeWindow();
             };
 


### PR DESCRIPTION
## Summary
- reset `snoozeAlreadyShown` when snoozing from overlay or popup

## Testing
- `dotnet build BreakTimer/BreakTimer/BreakTimer.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ccb1a7cc8326a053ad3e6ada776c