### PR TITLE
Ignore build outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 /.vs/BreakTimer/v17
 /BreakTimer/.vs/BreakTimer
+
+/BreakTimer/bin/
+/BreakTimer/obj/


### PR DESCRIPTION
## Summary
- update .gitignore so that build outputs aren't committed

## Testing
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68524018bb288326bbe2a16d78289171