### PR TITLE
Dispose tray icon on app exit

### DIFF
--- a/BreakTimer/BreakTimer/App.xaml.cs
+++ b/BreakTimer/BreakTimer/App.xaml.cs
@@ -163,7 +163,11 @@ namespace BreakTimer
             var exitItem = new ToolStripMenuItem("종료");
             exitItem.Click += (s, e) =>
             {
-                notifyIcon.Visible = false;
+                if (notifyIcon != null)
+                {
+                    notifyIcon.Dispose();
+                    notifyIcon = null;
+                }
                 Shutdown();
             };
             contextMenu.Items.Add(exitItem);
@@ -311,6 +315,16 @@ namespace BreakTimer
             shortcut.WindowStyle = 1;
             shortcut.Description = "BreakTimer 자동 시작";
             shortcut.Save();
+        }
+
+        protected override void OnExit(ExitEventArgs e)
+        {
+            if (notifyIcon != null)
+            {
+                notifyIcon.Dispose();
+                notifyIcon = null;
+            }
+            base.OnExit(e);
         }
     }
 }


### PR DESCRIPTION
## Summary
- dispose of tray icon when selecting the exit menu
- dispose of tray icon during app shutdown

## Testing
- `msbuild BreakTimer/BreakTimer.sln -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68524017a960832697867a6f550d4d10