### PR TITLE
Fix WorkTimer timer initialization

### DIFF
--- a/BreakTimer/BreakTimer/Timer.cs
+++ b/BreakTimer/BreakTimer/Timer.cs
@@ -18,8 +18,13 @@ namespace BreakTimer
 
         public void Start(int minutes)
         {
-            timer?.Stop();
-            timeLeft = TimeSpan.Zero;
+            if (timer != null)
+            {
+                timer.Stop();
+                timer.Tick -= Tick;
+                timer = null;
+            }
+
             timeLeft = TimeSpan.FromMinutes(minutes);
             timer = new DispatcherTimer();
             timer.Interval = TimeSpan.FromSeconds(1);


### PR DESCRIPTION
## Summary
- ensure WorkTimer unsubscribes from previous timer before starting a new one
- remove redundant reset of `timeLeft`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685240161e488326a264370ff994d34f