### PR TITLE
Add break timer stop handling

### DIFF
--- a/BreakTimer/BreakTimer/App.xaml.cs
+++ b/BreakTimer/BreakTimer/App.xaml.cs
@@ -244,6 +244,7 @@ namespace BreakTimer
                 };
                 overlay.OnClosedByUser = () => {
                     CloseOverlay();
+                    breakTimer.Stop();
                     workTimer.Start(workMinutes);
                     snoozeAlreadyShown = false;
                     this.isAway = false;

--- a/BreakTimer/BreakTimer/Timer.cs
+++ b/BreakTimer/BreakTimer/Timer.cs
@@ -55,6 +55,16 @@ namespace BreakTimer
         private TimeSpan timeLeft;
         private DispatcherTimer timer;
 
+        public void Stop()
+        {
+            if (timer != null)
+            {
+                timer.Stop();
+                timer = null;
+            }
+            timeLeft = TimeSpan.Zero;
+        }
+
         public void Start(int minutes)
         {
             timeLeft = TimeSpan.FromMinutes(minutes);


### PR DESCRIPTION
## Summary
- extend `RestTimer` with a `Stop()` method
- stop the break timer when overlay is closed by the user

## Testing
- `dotnet build` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852401291f48326bc087bf0ade7a49e